### PR TITLE
Allow Optional Basic Auth for TinyProxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,8 +101,10 @@ Might be needed, if NordVPN cannot change the settings itself.
 * PORTS: add ports to allow
 * LOCAL_NETWORK: add subnet to allow, multiple values possible net1, net2, net3, ....
 * DOCKER_NET: optional, docker CIDR extracted from container ip if not set. 
+* TINYUSER: optional, enforces authentication over tinyproxy when set with TINYPASS. 
+* TINYPASS: optional, enforces authentication over tinyproxy when set with TINYUSER. 
 
-### Authentication
+### NordVPN Authentication
 As of 23-12-2022, login with username and password are deprecated, as well as legacy. Username and password logins are allowed in the container, but may not be allowed by NordVPN. Login with a token is highly recommended. Tokens can be generated in your [NordAccount](https://my.nordaccount.com/dashboard/nordvpn).
 
 ### docker-compose example with env variables explained

--- a/app/tinyproxy_config.sh
+++ b/app/tinyproxy_config.sh
@@ -38,3 +38,6 @@ fi
 
 #show Conf
 [[ 1 -eq ${DEBUG} ]] && grep -vE "(^#|^$)" ${CONF} || true
+
+#basic Auth
+[[ -n ${TINYUSER}  ]] && [[ -n ${TINYPASS}  ]] && sed -i -r "s/#?BasicAuth user password/BasicAuth ${TINYUSER} ${TINYPASS}/" ${CONF} || true


### PR DESCRIPTION
Change to the app\tinyproxy_config.sh to allow optional fields to enable the BasicAuth in TinyProxy.conf.  If both fields are not defined the existing behavior is preserved. 

Rationale: I'm looking to have the proxy available on my network, and want to minimize access.

The two new Environment options are:
TINYUSER: Username for proxy access
TINYPASS: Password for proxy access

