### PR TITLE
Fixed `getEthCidr` to be calculated correctly when prefixlen is 32

### DIFF
--- a/app/utils.sh
+++ b/app/utils.sh
@@ -111,7 +111,7 @@ getEthIp() {
 }
 
 getEthCidr() {
-  ip -j a show eth0 | jq -r '.[].addr_info[0]|"\( .broadcast)/\(.prefixlen)"' | sed 's/255/0/g'
+  ip -j a show eth0 | jq -r '.[].addr_info[0]|"\( .broadcast // .local)/\(.prefixlen)"' | sed 's/255/0/g'
 }
 
 getTinyConf() {


### PR DESCRIPTION
When the prefix length of eth0 assigned to a container is 32, `.addr_info[0].broadcast` is not obtained correctly.

When I execute `$(getEthCidr)` in this environment, I get `null/32`. This results in an incorrect syntax error in /etc/sockd.conf and danted has entered the restart loop.
```
2025-01-23 20:14:37,056 INFO spawned: 'dante' with pid 15095
Jan 23 20:14:37 (1737630877.091232) danted[15095]: error: /etc/sockd.conf: problem on line 58 near token "/": syntax error.  Please see the Dante manual for more information
Jan 23 20:14:37 (1737630877.091481) danted[15095]: alert: mother[1/2]: shutting down
2025-01-23 20:14:37,092 INFO success: dante entered RUNNING state, process has stayed up for > than 0 seconds (startsecs)
2025-01-23 20:14:37,093 WARN exited: dante (exit status 1; not expected)
```

FYI, the output of the ip command was as follows
```console
root@deployment-56687bf498-fq6q2:/app# ip -j a show eth0 | jq
[
  {
    "ifindex": 104983,
    "link_index": 104984,
    "ifname": "eth0",
    "flags": [
      "BROADCAST",
      "MULTICAST",
      "UP",
      "LOWER_UP"
    ],
    "mtu": 9000,
    "qdisc": "noqueue",
    "operstate": "UP",
    "group": "57841",
    "txqlen": 1000,
    "link_type": "ether",
    "address": "<redacted>",
    "broadcast": "ff:ff:ff:ff:ff:ff",
    "link_netnsid": 0,
    "addr_info": [
      {
        "family": "inet",
        "local": "10.0.0.11",
        "prefixlen": 32,
        "scope": "global",
        "label": "eth0",
        "valid_life_time": 4294967295,
        "preferred_life_time": 4294967295
      }
    ]
  }
]
```

So I fixed `getEthCidr` to fall back to `.addr_info[0].local` if `.addr_info[0].broadcast` is missing.

note: the `//` operator is jq's alternative operator.
- https://jqlang.github.io/jq/manual/#alternative-operator